### PR TITLE
Refactor of location layers to support tracking and navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "quasar dev",
     "mobile": "quasar dev -m cordova -T android",
     "mobile-update": "quasar build -m android --skip-pkg",
-    "build-mobile": "quasar build -m android"
+    "build-mobile": "quasar build -m android",
+    "build-mobile-test": "quasar build -m android --debug"
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",

--- a/src-cordova/package-lock.json
+++ b/src-cordova/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "cordova-android": "^11.0.0",
-        "cordova-background-geolocation-plugin": "^2.0.8"
+        "cordova-background-geolocation-plugin": "^2.0.8",
+        "cordova-plugin-geolocation": "^4.1.0"
       }
     },
     "node_modules/@netflix/nerror": {
@@ -257,6 +258,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cordova-plugin-geolocation": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-geolocation/-/cordova-plugin-geolocation-4.1.0.tgz",
+      "integrity": "sha512-y5io/P10xGMxSn2KEqfv/fExK47eA1pmSonJdmDqDsaSADV9JpgdPx0mUSA08+5pzma/OS9R0LoODeDPx7Jvjg==",
+      "dev": true,
+      "engines": {
+        "cordovaDependencies": {
+          "3.0.0": {
+            "cordova-android": ">=6.3.0"
+          },
+          "5.0.0": {
+            "cordova": ">100"
+          }
+        }
       }
     },
     "node_modules/cross-spawn": {
@@ -1173,6 +1190,12 @@
           }
         }
       }
+    },
+    "cordova-plugin-geolocation": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-geolocation/-/cordova-plugin-geolocation-4.1.0.tgz",
+      "integrity": "sha512-y5io/P10xGMxSn2KEqfv/fExK47eA1pmSonJdmDqDsaSADV9JpgdPx0mUSA08+5pzma/OS9R0LoODeDPx7Jvjg==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/src-cordova/package.json
+++ b/src-cordova/package.json
@@ -14,7 +14,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "cordova-android": "^11.0.0",
-    "cordova-background-geolocation-plugin": "^2.0.8"
+    "cordova-background-geolocation-plugin": "^2.0.8",
+    "cordova-plugin-geolocation": "^4.1.0"
   },
   "cordova": {
     "platforms": [
@@ -29,6 +30,10 @@
         "ACCOUNT_LABEL": "@string/app_name",
         "ACCOUNT_TYPE": "$PACKAGE_NAME.account",
         "CONTENT_AUTHORITY": "$PACKAGE_NAME"
+      },
+      "cordova-plugin-device-orientation": {},
+      "cordova-plugin-geolocation": {
+        "GPS_REQUIRED": "true"
       }
     }
   }

--- a/src/components/map/layers/LocationLayers.vue
+++ b/src/components/map/layers/LocationLayers.vue
@@ -21,6 +21,7 @@ import NavigationLayer from './NavigationLayer.vue'
 import { useLocationStore } from 'stores/location-store'
 export default {
   props: ['view'],
+  emits: ['centerChanged'],
   components: { TrackingLayer, NavigationLayer },
   setup () {
     const store = useLocationStore()
@@ -50,6 +51,7 @@ export default {
       return this.store.getMyLocation
     },
     myLocationCoordinates () {
+      this.$emit('centerChanged', this.store.getMyLocationCoordinates)
       return this.store.getMyLocationCoordinates
     }
   }

--- a/src/components/map/layers/NavigationLayer.vue
+++ b/src/components/map/layers/NavigationLayer.vue
@@ -1,0 +1,51 @@
+<template>
+ <ol-vector-layer>
+    <ol-source-vector>
+      <ol-feature>
+        <ol-geom-line-string :coordinates="navigateTo"></ol-geom-line-string>
+          <ol-style>
+            <ol-style-stroke :color="strokeColor" :width="strokeWidth"></ol-style-stroke>
+          </ol-style>
+      </ol-feature>
+    </ol-source-vector>
+  </ol-vector-layer>
+</template>
+
+<script>
+import { fromLonLat } from 'ol/proj'
+import { ref } from 'vue'
+import { useLocationStore } from 'stores/location-store'
+// add top template where user can see distance, direction and can cancelcoo
+export default {
+  setup () {
+    const store = useLocationStore()
+    const strokeWidth = ref(3)
+    const strokeColor = ref('green')
+    store.registerForLocationUpdates({
+      locationUpdated: (location) => {
+        const coords = fromLonLat([location.longitude, location.latitude])
+        if (store.getNavigationActive) {
+          store.updateNavigation(coords)
+        }
+      },
+      locationStopped: () => {
+        console.log('location terminated')
+        if (!store.getNavigationActive) {
+          store.updateNavigation([])
+        }
+      }
+    })
+
+    return {
+      store,
+      strokeWidth,
+      strokeColor
+    }
+  },
+  computed: {
+    navigateTo () {
+      return this.store.getNavigateTo
+    }
+  }
+}
+</script>

--- a/src/components/map/layers/NavigationLayer.vue
+++ b/src/components/map/layers/NavigationLayer.vue
@@ -1,4 +1,18 @@
 <template>
+  <q-dialog v-model="navigationInProgress" :position="position" seamless class="q-dialog__top50">
+      <q-card style="width: 350px">
+        <q-card-section class="row items-center no-wrap">
+          <div>
+            <div class="text-weight-bold">Go to: {{ name }}</div>
+            <div class="text-grey">Distance: {{ distance }} {{ distanceUnit }}</div>
+          </div>
+
+          <q-space />
+          <q-icon name="navigation" :style="{ rotate: bearing + 'deg' }" size="lg" />
+          <q-btn flat round icon="stop" @click="stopNavigation"/>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
  <ol-vector-layer>
     <ol-source-vector>
       <ol-feature>
@@ -15,9 +29,13 @@
 import { fromLonLat } from 'ol/proj'
 import { ref } from 'vue'
 import { useLocationStore } from 'stores/location-store'
-// add top template where user can see distance, direction and can cancel
+import LineString from 'ol/geom/LineString'
+import { getLength } from 'ol/sphere'
+
 export default {
   setup () {
+    const dialog = ref(true)
+    const position = ref('top')
     const store = useLocationStore()
     const strokeWidth = ref(3)
     const strokeColor = ref('green')
@@ -37,15 +55,69 @@ export default {
     })
 
     return {
+      dialog,
+      position,
       store,
       strokeWidth,
       strokeColor
     }
   },
+  data () {
+    return {
+      currentCenter: this.center,
+      currentZoom: this.zoom,
+      currentResolution: this.resolution,
+      fixedCenter: false,
+      name: this.$route.query.name
+    }
+  },
   computed: {
+    bearing () {
+      const directionBetweenTwoPoints = ([x1, y1], [x2, y2]) => {
+        const x = x2 - x1
+        const y = y2 - y1
+        return ((Math.atan2(x, y) * 180 / Math.PI) + 360) % 360
+      }
+      const direction = directionBetweenTwoPoints(this.store.getNavigateTo[1], this.store.getNavigateTo[0])
+
+      return direction - this.store.getRotation
+    },
     navigateTo () {
       return this.store.getNavigateTo
+    },
+    navigationInProgress () {
+      return this.store.getNavigateTo.length > 0
+    },
+    distance () {
+      const line = new LineString(this.store.getNavigateTo)
+      const distanceInMeters = getLength(line)
+      if (distanceInMeters > 1000) {
+        return (distanceInMeters / 1000).toFixed(2)
+      }
+      return parseInt(distanceInMeters)
+    },
+    distanceUnit () {
+      const line = new LineString(this.store.getNavigateTo)
+      const distanceInMeters = getLength(line)
+      if (distanceInMeters > 1000) {
+        return 'km'
+      }
+      return 'm'
+    }
+  },
+  methods: {
+    stopNavigation () {
+      this.store.stopNavigation()
     }
   }
 }
 </script>
+<style>
+.q-dialog__top50 {
+  top: 50px;
+  z-index: 1000;
+}
+.q-dialog__inner--top {
+  top: 50px;
+}
+</style>

--- a/src/components/map/layers/NavigationLayer.vue
+++ b/src/components/map/layers/NavigationLayer.vue
@@ -26,7 +26,6 @@
 </template>
 
 <script>
-import { fromLonLat } from 'ol/proj'
 import { ref } from 'vue'
 import { useLocationStore } from 'stores/location-store'
 import LineString from 'ol/geom/LineString'
@@ -39,20 +38,6 @@ export default {
     const store = useLocationStore()
     const strokeWidth = ref(3)
     const strokeColor = ref('green')
-    store.registerForLocationUpdates({
-      locationUpdated: (location) => {
-        const coords = fromLonLat([location.longitude, location.latitude])
-        if (store.getNavigationActive) {
-          store.updateNavigation(coords)
-        }
-      },
-      locationStopped: () => {
-        console.log('location terminated')
-        if (!store.getNavigationActive) {
-          store.updateNavigation([])
-        }
-      }
-    })
 
     return {
       dialog,

--- a/src/components/map/layers/NavigationLayer.vue
+++ b/src/components/map/layers/NavigationLayer.vue
@@ -15,7 +15,7 @@
 import { fromLonLat } from 'ol/proj'
 import { ref } from 'vue'
 import { useLocationStore } from 'stores/location-store'
-// add top template where user can see distance, direction and can cancelcoo
+// add top template where user can see distance, direction and can cancel
 export default {
   setup () {
     const store = useLocationStore()

--- a/src/components/map/layers/TrackingLayer.vue
+++ b/src/components/map/layers/TrackingLayer.vue
@@ -12,7 +12,6 @@
 </template>
 
 <script>
-import { fromLonLat } from 'ol/proj'
 import { ref } from 'vue'
 import { useLocationStore } from 'stores/location-store'
 
@@ -21,17 +20,6 @@ export default {
     const store = useLocationStore()
     const strokeWidth = ref(5)
     const strokeColor = ref('red')
-    store.registerForLocationUpdates({
-      locationUpdated: (location) => {
-        const coords = fromLonLat([location.longitude, location.latitude])
-        if (store.getLocationTracking) {
-          store.updateMyTrack(coords)
-        }
-      },
-      locationStopped: () => {
-        console.log('location terminated. TODO: handle track (delete or save)')
-      }
-    })
 
     return {
       store,

--- a/src/components/map/layers/TrackingLayer.vue
+++ b/src/components/map/layers/TrackingLayer.vue
@@ -1,0 +1,48 @@
+<template>
+  <ol-vector-layer>
+    <ol-source-vector>
+      <ol-feature>
+        <ol-geom-line-string :coordinates="myTrack"></ol-geom-line-string>
+          <ol-style>
+            <ol-style-stroke :color="strokeColor" :width="strokeWidth"></ol-style-stroke>
+          </ol-style>
+      </ol-feature>
+    </ol-source-vector>
+  </ol-vector-layer>
+</template>
+
+<script>
+import { fromLonLat } from 'ol/proj'
+import { ref } from 'vue'
+import { useLocationStore } from 'stores/location-store'
+
+export default {
+  setup () {
+    const store = useLocationStore()
+    const strokeWidth = ref(5)
+    const strokeColor = ref('red')
+    store.registerForLocationUpdates({
+      locationUpdated: (location) => {
+        const coords = fromLonLat([location.longitude, location.latitude])
+        if (store.getLocationTracking) {
+          store.updateMyTrack(coords)
+        }
+      },
+      locationStopped: () => {
+        console.log('location terminated. TODO: handle track (delete or save)')
+      }
+    })
+
+    return {
+      store,
+      strokeWidth,
+      strokeColor
+    }
+  },
+  computed: {
+    myTrack () {
+      return this.store.getMyTrack
+    }
+  }
+}
+</script>

--- a/src/pages/CaveSearchPage.vue
+++ b/src/pages/CaveSearchPage.vue
@@ -111,7 +111,8 @@ export default {
         query: {
           lat: this.selectedCave.lat,
           lng: this.selectedCave.lng,
-          navigate: true
+          navigate: true,
+          name: `${this.selectedCave.caveNumber} - ${this.selectedCave.name}`
         }
       })
     },

--- a/src/pages/CaveSearchPage.vue
+++ b/src/pages/CaveSearchPage.vue
@@ -102,13 +102,10 @@ export default {
   methods: {
     goTo ({ reset }, cave) {
       reset()
-      console.log('go to cave (TODO): ', cave)
       this.selectedCave = cave
       this.confirm = true
     },
     navigateToSelectedCave () {
-      console.log('navigateToSelectedCave to cave (TODO): ', this.selectedCave)
-
       this.$router.push({
         path: '/',
         query: {

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -12,7 +12,9 @@
         @centerChanged="centerChanged"
         @resolutionChanged="resolutionChanged"/>
       <CartoLayers/>
-      <LocationLayers :view="view"/>
+      <LocationLayers
+        :view="view"
+        @centerChanged="centerChanged"/>
 
       <ol-vector-layer>
         <ol-source-vector :features="markLocations">
@@ -107,6 +109,9 @@ export default defineComponent({
       this.currentResolution = resolution
     },
     centerChanged (center) {
+      if (this.view === '') {
+        return
+      }
       this.currentCenter = center
       if (this.view.getInteracting()) {
         this.fixedCenter = false

--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -28,9 +28,6 @@
     <q-page-sticky position="bottom-right" :offset="[18, 18]">
       <q-btn fab :icon="trackLocationIcon ? 'stop_circle' : 'play_arrow'" color="accent" @click="trackingClicked" />
     </q-page-sticky>
-    <q-page-sticky position="bottom-right" :offset="[18, 90]" v-if="navigationActive">
-      <q-btn fab icon="stop_circle" color="red" @click="stopNavigation"/>
-    </q-page-sticky>
   </PageFullScreen>
 </template>
 
@@ -118,9 +115,6 @@ export default defineComponent({
       } else if (this.fixedCenter) {
         this.center = center
       }
-    },
-    stopNavigation () {
-      this.store.stopNavigation()
     }
   },
   watch: {

--- a/src/stores/location-store.js
+++ b/src/stores/location-store.js
@@ -1,0 +1,153 @@
+import { defineStore } from 'pinia'
+import { Platform } from 'quasar'
+
+export const useLocationStore = defineStore('location', {
+  state: () => ({
+    locationUpdates: [],
+    foregroundLocationActivated: false,
+    isCordova: Platform.is.cordova,
+    projection: null,
+    rotation: 45,
+    watchId: null,
+    locationTracking: false,
+    navigationActive: false,
+    myLocation: [],
+    myLocationCoordinates: [],
+    myTrack: [],
+    navigateTo: []
+  }),
+
+  getters: {
+    getProjection (state) {
+      return state.projection
+    },
+    getRotation (state) {
+      return state.rotation
+    },
+    getLocationTracking (state) {
+      return state.locationTracking
+    },
+    getNavigationActive (state) {
+      return state.navigationActive
+    },
+    getMyLocation (state) {
+      return state.myLocation
+    },
+    getMyLocationCoordinates (state) {
+      return state.myLocationCoordinates
+    },
+    getMyTrack (state) {
+      return state.myTrack
+    },
+    getNavigateTo (state) {
+      return state.navigateTo
+    },
+    getIsLocationNeeded (state) {
+      return !state.locationTracking && !state.navigationActive
+    }
+  },
+  actions: {
+    initialize (projection) {
+      this.projection = projection
+      if (this.isCordova) {
+        window.BackgroundGeolocation.configure({
+          locationProvider: window.BackgroundGeolocation.DISTANCE_FILTER_PROVIDER,
+          desiredAccuracy: window.BackgroundGeolocation.MEDIUM_ACCURACY,
+          stationaryRadius: 10,
+          distanceFilter: 10, // only when using location provider: DISTANCE_FILTER_PROVIDER
+          stopOnTerminate: false,
+          debug: true,
+          startForeground: true,
+          notificationsEnabled: true, // try using non background and then apply foreground when start tracking or when start navigation in this case location button can be used to center to current location
+          httpHeaders: { 'X-Auth': 'če ga rabiš' },
+          interval: 5000, // only when using location provider: ACTIVITY_PROVIDER
+          fastestInterval: 2000, // only when using location provider: ACTIVITY_PROVIDER
+          activitiesInterval: 1000 // only when using location provider: ACTIVITY_PROVIDER
+          // url: 'https://katasterjam.si/api/track',
+          // syncUrl: 'https://katasterjam.si/api/sync'
+        })
+
+        window.BackgroundGeolocation.on('authorization', (status) => {
+          if (status !== window.BackgroundGeolocation.AUTHORIZED) {
+            setTimeout(() => {
+              navigator.notification.confirm('Please enable location access', b => {
+                if (b === 1) {
+                  window.BackgroundGeolocation.showAppSettings()
+                }
+              }, 'Kataster jam')
+            }, 1000)
+          }
+        })
+
+        window.BackgroundGeolocation.on('location', (location) => {
+          this.locationUpdates.map(update => update.locationUpdated(location, this.projection))
+        })
+
+        navigator.geolocation.watchPosition((position) => {
+          this.locationUpdates.map(update => update.locationUpdated(position.coords, this.projection))
+        })
+        this.watchId = navigator.compass.watchHeading((heading) => {
+          this.rotation = heading.magneticHeading
+        }, (compassError) => {
+          alert('Compass error: ' + compassError.code)
+        }, {
+          frequency: 1000
+        })
+      }
+    },
+    toggleLocationTracking () {
+      this.locationTracking = !this.locationTracking
+      window.BackgroundGeolocation.configure({
+        notificationTitle: 'Location tracking',
+        notificationText: 'Tracking your location is in progress'
+      })
+      this.locationTracking ? this.startForeground() : this.stopForeground()
+    },
+    stopNavigation () {
+      this.navigationActive = false
+      this.stopForeground()
+    },
+    startNavigation (goTo) {
+      this.goTo = goTo
+      if (this.navigateTo.length === 2) {
+        this.navigateTo[0] = this.goTo.getGeometry().getCoordinates()
+      }
+      window.BackgroundGeolocation.configure({
+        notificationTitle: 'Navigation',
+        notificationText: 'Navigation to a location is in progress'
+      })
+      this.navigationActive = true
+      this.startForeground()
+    },
+    startForeground () {
+      if (!this.foregroundLocationActivated) {
+        if (this.isCordova) {
+          window.BackgroundGeolocation.start()
+        }
+        this.foregroundLocationActivated = true
+      }
+    },
+    stopForeground () {
+      if (this.foregroundLocationActivated && this.getIsLocationNeeded) {
+        if (this.isCordova) {
+          window.BackgroundGeolocation.stop()
+        }
+        this.foregroundLocationActivated = false
+      }
+      this.locationUpdates.map(update => update.locationStopped())
+    },
+    registerForLocationUpdates (locationUpdate) {
+      this.locationUpdates.push(locationUpdate)
+    },
+    updateMyLocation (coords, myLocation) {
+      this.myLocation = myLocation
+      this.myLocationCoordinates = coords
+    },
+    updateMyTrack (coords) {
+      this.myTrack.push(coords)
+    },
+    updateNavigation (coords) {
+      this.navigateTo = coords.length === 0 ? [] : [this.goTo.getGeometry().getCoordinates(), coords]
+    }
+  }
+})


### PR DESCRIPTION
I started with a refactoring of the location layer. I want to support users to:
- track his location (and later store/share that track)
- be navigated to a specific location
- location updates should be active all the time

But I'm having issues with the last one: when the user starts using this app, the location should be turned on and show a location marker on the map. This location doesn't have to run in [back/fore]ground (no notification needed). Also if the application is closed, the location should be turned off. But when the user starts navigation/tracking it should use foreground location. Similar to how (for example) Locus maps work. In the future, I would also enable users to turn this off completely. 

For this I tried using `navigator.geolocation.watchPosition` but for some reason, it's not working as it should. I think it's using a location provider from WIFI or LTE (I'm not sure) but not GPS (there is no android icon shown). I'm not sure if this is again a problem with my phone or if there is another way to achieve this. Did you ever experience anything similar? Do you have any idea how to solve this?