### PR TITLE
basic click info drawer

### DIFF
--- a/src/components/map/drawer/DetailsDrawer.vue
+++ b/src/components/map/drawer/DetailsDrawer.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="q-pa-md q-gutter-sm">
+    <q-dialog v-model="dialog" position="bottom" @hide="hideDrawer">
+      <q-card style="width: 350px;">
+        <q-card-section v-if="drawerLoading" class="row justify-center items-center" >
+          <q-spinner
+            color="primary"
+            size="3em"
+            :thickness="2"
+          />
+        </q-card-section>
+        <q-card-section v-else class="row items-center no-wrap">
+          <div>
+            <div class="text-weight-bold" v-if="clickedFeature.type !== 'click'">[{{ clickedFeature.id }}] {{ clickedFeature.name }}</div>
+            <div class="text-weight-bold" v-else>{{ $t('clickInfo') }}:</div>
+            <div class="text-grey" v-if="clickedFeature.type === 'cave'">{{ $t('length') }}: {{ clickedFeature.length }} m, {{ $t('depth') }}: {{ clickedFeature.depth }} m</div>
+            <div class="text-grey">{{ $t('lat') }}: {{ clickedFeature.lat }}, {{ $t('lng') }}: {{ clickedFeature.lng }}</div>
+          </div>
+          <q-space />
+          <q-btn flat round icon="info" v-if="clickedFeature.type !== 'click'" @click="info(clickedFeature.id)"/>
+          <q-btn flat round icon="assist_walker"  @click="goTo()"/>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+<script>
+import { useQuasar } from 'quasar'
+import { ref } from 'vue'
+import { fromLonLat } from 'ol/proj'
+import Point from 'ol/geom/Point'
+import { Feature } from 'ol'
+import { storeToRefs } from 'pinia'
+import { useMapStore } from 'stores/map-store'
+import { useLocationStore } from 'stores/location-store'
+
+export default {
+  setup () {
+    const quasar = useQuasar()
+    const mapStore = useMapStore()
+    const locationStore = useLocationStore()
+    mapStore.hideDrawer()
+    const dialog = ref(false)
+    const { showBottomDrawer } = storeToRefs(mapStore)
+
+    return {
+      dialog,
+      confirmDialog: quasar.dialog,
+      mapStore,
+      locationStore,
+      showBottomDrawer
+    }
+  },
+  computed: {
+    clickedFeature () {
+      return this.mapStore.getClickedFeature
+    },
+    drawerLoading () {
+      return this.mapStore.getDrawerLoading
+    }
+  },
+  methods: {
+    hideDrawer () {
+      this.mapStore.hideDrawer()
+    },
+    goTo () {
+      const name = `[${this.clickedFeature.id}] ${this.clickedFeature.name}`
+      this.confirmDialog({
+        title: `${this.$t('confirm')}`,
+        message: `${this.$t(this.clickedFeature.type === 'cave' ? 'navigateToCave' : 'navigateToCustomLocation')}: ${name}`,
+        cancel: true,
+        persistent: true
+      }).onOk(() => {
+        const coords = fromLonLat([this.clickedFeature.lng, this.clickedFeature.lat])
+        const mark = new Feature(new Point(coords))
+        this.locationStore.startNavigation(mark)
+      })
+    },
+    info (id) {
+      this.$router.push({
+        name: this.clickedFeature.type === 'cave' ? 'caves-details' : 'custom-locations-details',
+        params: { id }
+      })
+    }
+  },
+  watch: {
+    showBottomDrawer (newValue, oldValue) {
+      this.dialog = newValue
+    }
+  }
+}
+</script>

--- a/src/components/map/layers/CustomLocationLayers.vue
+++ b/src/components/map/layers/CustomLocationLayers.vue
@@ -3,7 +3,10 @@
     <ol-source-vector ref="vectorSource">
     <ol-feature v-for="customLocation in customLocations" :key="customLocation.id" :properties="{
         'id': customLocation.id,
-        'name': customLocation.name
+        'name': customLocation.name,
+        'lat': customLocation.lat.toFixed(5),
+        'lng': customLocation.lng.toFixed(5),
+        'type': 'poi'
       }">
         <ol-geom-point :coordinates="customLocation.latLng"></ol-geom-point>
 
@@ -26,8 +29,6 @@ export default {
     const customLocations = ref([])
     const vectorSource = ref(new VectorSource())
     store.loadForMap().then(() => {
-      console.log('locations loaded')
-
       store.customLocationsForMap.map(cl => customLocations.value.push(cl))
     })
 

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -130,5 +130,8 @@ export default {
   elevationAbrv: 'm.a.s.l.',
   geology: 'Geology',
   settlement: 'Settlement',
-  municipalty: 'Municipality'
+  municipalty: 'Municipality',
+  lat: 'Latitude',
+  lng: 'Longitude',
+  clickInfo: 'Click info'
 }

--- a/src/i18n/sl-SI/index.js
+++ b/src/i18n/sl-SI/index.js
@@ -130,5 +130,8 @@ export default {
   elevationAbrv: 'n. m. v.',
   geology: 'Geologija',
   settlement: 'Nasleje',
-  municipalty: 'Občina'
+  municipalty: 'Občina',
+  lat: 'Širina',
+  lng: 'Dolžina',
+  info: 'Informacija o kliku'
 }

--- a/src/pages/CaveSearchPage.vue
+++ b/src/pages/CaveSearchPage.vue
@@ -127,7 +127,7 @@ export default {
     caveClick (caveNumber) {
       this.$router.push({
         name: 'caves-details',
-        params: { caveNumber }
+        params: { id: caveNumber }
       })
     },
     showOnMapClick (cave) {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,7 +1,7 @@
 import { api } from 'src/boot/axios'
 
 const caveResolver = async (to, from, next) => {
-  const response = await api.get(`/api/caves/${to.params.caveNumber}`)
+  const response = await api.get(`/api/caves/${to.params.id}`)
   to.meta.cave = response.data
   next()
 }
@@ -29,7 +29,7 @@ const routes = [
     children: [
       { path: '', name: 'home', component: () => import('pages/IndexPage.vue') },
       { path: '/caves', name: 'caves', component: () => import('pages/CaveSearchPage.vue') },
-      { path: '/caves/details/:caveNumber', name: 'caves-details', component: () => import('pages/CaveDetailsPage.vue'), beforeEnter: caveResolver },
+      { path: '/caves/details/:id', name: 'caves-details', component: () => import('pages/CaveDetailsPage.vue'), beforeEnter: caveResolver },
       { path: '/trips', name: 'trips', component: () => import('pages/TripSearchPage.vue') },
       { path: '/trips/details/:id', name: 'trips-details', component: () => import('src/pages/TripDetailsPage.vue'), beforeEnter: excursionResolver },
       { path: '/custom-locations', name: 'custom-locations', component: () => import('pages/CustomLocationSearchPage.vue') },

--- a/src/stores/map-store.js
+++ b/src/stores/map-store.js
@@ -1,7 +1,10 @@
 import { defineStore } from 'pinia'
+import * as olProj from 'ol/proj'
+import { EsriJSON } from 'ol/format'
 
 export const useMapStore = defineStore('map', {
   state: () => ({
+    mapRef: null,
     layers: [{
       active: false,
       label: 'Lidar',
@@ -18,11 +21,87 @@ export const useMapStore = defineStore('map', {
       projection: 'EPSG:3912',
       attributes: 'Ortophoto podlaga, GURS',
       preview: 'map/ortophoto.png'
-    }]
+    }],
+    bottomDrawer: false,
+    drawerLoading: false,
+    clickedFeature: {}
   }),
   getters: {
     getLayers (state) {
       return state.layers
+    },
+    getClickedFeature (state) {
+      return state.clickedFeature
+    },
+    getDrawerLoading (state) {
+      return state.drawerLoading
+    },
+    showBottomDrawer (state) {
+      return state.bottomDrawer
+    },
+    getMap (state) {
+      return state.mapRef.map
+    }
+  },
+  actions: {
+    async mapClick (coordinates, featuresClick) {
+      this.bottomDrawer = true
+      this.drawerLoading = true
+      try {
+        const lngLat = olProj.toLonLat(coordinates)
+        this.clickedFeature = {
+          lat: lngLat[1].toFixed(5),
+          lng: lngLat[0].toFixed(5),
+          type: 'click'
+        }
+        const features = featuresClick.filter(f => f.values_.type === 'poi')
+        if (features.length > 0) {
+          this.clickedFeature = {
+            ...features[0].values_
+          }
+        } else {
+          const result = await this.getRemoteFeatures(coordinates)
+          if (result.length > 0) {
+            const cave = result[0]
+            this.clickedFeature = {
+              id: cave.values_.CaveNumber,
+              name: cave.values_.Name,
+              lat: cave.values_.Lat,
+              lng: cave.values_.Lon,
+              length: cave.values_.Length,
+              depth: cave.values_.Depth,
+              type: 'cave'
+            }
+          }
+        }
+      } catch (error) {
+        console.log('error while fetching data: ', error)
+      } finally {
+        this.drawerLoading = false
+      }
+    },
+    hideDrawer () {
+      this.bottomDrawer = false
+    },
+    saveMapRef (mapRef) {
+      this.mapRef = mapRef
+    },
+    async getRemoteFeatures (coordinate) {
+      let distance = 4000 / Math.pow(2, (this.getMap.getView().getZoom() - 9))
+      distance = distance < 5 ? 5 : distance
+      const url = 'https://services7.arcgis.com/V2VriwTjJDabpGg6/arcgis/rest/services/2023_marec_export_ekataster_a/FeatureServer/0/query/?f=json&' +
+        'returnGeometry=true&geometry=' +
+        encodeURIComponent('{"x":' + (coordinate[0]) + ',"y":' + (coordinate[1]) + ',"spatialReference":{"wkid":102100}}') +
+        `&distance=${distance}` +
+        '&geometryType=esriGeometryPoint&inSR=102100&outFields=*&outSR=102100'
+      const response = await fetch(url)
+      const val = await response.text()
+      const esriJsonFormat = new EsriJSON()
+      const features = esriJsonFormat.readFeatures(val, {
+        featureProjection: this.getMap.getView().getProjection()
+      })
+
+      return features
     }
   }
 })


### PR DESCRIPTION
@jeancaffou I have one question regarding this:
```javascript
setTimeout(async () => {
    await this.onMapClick(evt)
}, '100')
```
with this "hack" I was able to achieve opening dialog both on mobile and web versions. If I skip the delay, on mobile, a dialog will be immediately closed. Since I guess the click event is also picked up by dialog backdrop. Did you have any similar issues before? 


Closes #16 
Closes #17 